### PR TITLE
Leverage `this.pickFiles` from within `postprocessTree`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 /* jshint node: true */
 // 'use strict';
 
-var pickFiles   = require('broccoli-static-compiler'),
-    vulcanize = require('broccoli-vulcanize');
+var vulcanize = require('broccoli-vulcanize');
 
 module.exports = {
   name: 'ember-polymer',
@@ -34,7 +33,7 @@ module.exports = {
       }
     });
 
-    var polymer = pickFiles('bower_components/', {
+    var polymer = this.pickFiles('bower_components/', {
       srcDir: '',
       files: [
       'webcomponentsjs/webcomponents.js',


### PR DESCRIPTION
This allows for any consumers to not need to require `broccoli-static-compiler`.

Great addon, just sending a mini-PR your way based on something I just experienced.